### PR TITLE
fix: bin folder doesn't build bin/commands folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
         "version": "npm run format && git add -A src",
         "postversion": "git push && git push --tags"
     },
-    "bin": {
-        "cmp": "./bin/cmp.js"
+    "directories":{
+        "bin":"./bin"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
Error complaining that there is no /bin/commands folder.

Looking into the bin folder, I seem to find only the cmp.js file.

Looking for options, I found the directories.bin option (https://docs.npmjs.com/cli/v7/configuring-npm/package-json#directoriesbin) is used to include more than one file for bin.

Output error:
```
yarn run v1.22.10
$ node_modules/.bin/cmp --version
internal/fs/utils.js:220
    throw err;
    ^

Error: ENOENT: no such file or directory, scandir '/Users/isma/Documents/Prototyp/Gapminder/ignofix-web/node_modules/@prototyp-stockholm/contentful-migrator-programme/bin/commands'
    at Object.readdirSync (fs.js:854:3)
    at requireDirectory (/Users/isma/Documents/Prototyp/Gapminder/ignofix-web/node_modules/require-directory/index.js:59:6)
    at Object.addDirectory (/Users/isma/Documents/Prototyp/Gapminder/ignofix-web/node_modules/yargs/build/lib/command.js:110:9)
    at Object.Yargs.self.commandDir (/Users/isma/Documents/Prototyp/Gapminder/ignofix-web/node_modules/yargs/build/lib/yargs.js:379:17)
    at Object.<anonymous> (/Users/isma/Documents/Prototyp/Gapminder/ignofix-web/node_modules/@prototyp-stockholm/contentful-migrator-programme/bin/cmp.js:5:6)
    at Module._compile (internal/modules/cjs/loader.js:956:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:973:10)
    at Module.load (internal/modules/cjs/loader.js:812:32)
    at Function.Module._load (internal/modules/cjs/loader.js:724:14)
    at Function.Module.runMain (internal/modules/cjs/loader.js:1025:10) {
  errno: -2,
  syscall: 'scandir',
  code: 'ENOENT',
  path: '/Users/isma/Documents/Prototyp/Gapminder/ignofix-web/node_modules/@prototyp-stockholm/contentful-migrator-programme/bin/commands'
}
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```