### PR TITLE
feat: adds dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: 'daily'
+    open-pull-requests-limit: 10
+


### PR DESCRIPTION
The schedule interval is set to "daily" for now, it should be changed to weekly once all deps are updated