### PR TITLE
fix: 100 migration limit due to bad api request

### DIFF
--- a/lib/contentful-space-manager.js
+++ b/lib/contentful-space-manager.js
@@ -79,6 +79,7 @@ class Space {
     async getEntries(type, options = {}) {
         const response = await this.env.getEntries({
             content_type: type,
+            limit: 1000,
             ...options,
         })
         return response.items


### PR DESCRIPTION
The current tool only fetches the first 100 migrations since the default API request limit is set to 100. Therefore the migration tool tries to apply the all migrations which where not in the first 100 migrations.